### PR TITLE
Add CI workflow: run tests on PRs and pushes to master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Run tests
+        run: uv run pytest


### PR DESCRIPTION
## Summary

- Runs `pytest` on every PR and every push to `master`
- Uses `astral-sh/setup-uv` with caching for fast installs

## Test plan

- [ ] Merge this PR and verify the workflow appears in the Actions tab
- [ ] Open a subsequent PR and confirm tests run automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)